### PR TITLE
fixed creating two connections instead of one cause close event handl…

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -40,8 +40,20 @@ export default class RabbitMqQueue {
     const {url, amqpOptions, reconnectDelaySecond} = this.options
     try {
       const connection = await amqplib.connect(url, amqpOptions)
-      connection.on('error', () => this.reconnect())
-      connection.on('close', () => this.reconnect())
+
+      let connectionRestoring = true;
+      connection.on('error', () => {
+        if (connectionRestoring) {
+          connectionRestoring = false
+          this.reconnect()
+        }
+      })
+      connection.on('close', () => {
+        if (connectionRestoring){
+          connectionRestoring = false
+          this.reconnect()
+        }
+      })
 
       console.log('[RabbitMQ] Connection successful.')
       this.connecting = false


### PR DESCRIPTION
fixed bug where close event handler emitting after error handler and because of this creates two channels. Here amqplib reference docs: https://amqp-node.github.io/amqplib/channel_api.html#model_events